### PR TITLE
Add nodejs (and possibly old browsers) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Mathias Biilmann Christensen",
   "bugs": "https://github.com/netlify/micro-api-client-lib/issues",
   "dependencies": {
+    "es6-promise": "^4.2.4",
+    "isomorphic-base64": "^1.0.2",
+    "isomorphic-fetch": "^2.2.1",
     "micro-api-client": "^3.2.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+/* Fetch polyfill for node and old browsers ; should be moved into micro-api-client */
+require('es6-promise').polyfill();
+require('isomorphic-fetch');
+
 import API, { JSONHTTPError } from "micro-api-client";
 import User from "./user";
 

--- a/src/user.js
+++ b/src/user.js
@@ -1,5 +1,7 @@
 import API, { JSONHTTPError } from "micro-api-client";
 import Admin from "./admin";
+import storage from "./utils/storage";
+import atob from "./utils/atob";
 
 const ExpiryMargin = 60 * 1000;
 const storageKey = "gotrue.user";
@@ -18,7 +20,7 @@ export default class User {
   }
 
   static removeSavedSession() {
-    localStorage.removeItem(storageKey);
+    storage.removeItem(storageKey);
   }
 
   static recoverSession(apiInstance) {
@@ -26,7 +28,7 @@ export default class User {
       return currentUser;
     }
 
-    const json = localStorage.getItem(storageKey);
+    const json = storage.getItem(storageKey);
     if (json) {
       try {
         const data = JSON.parse(json);
@@ -157,7 +159,7 @@ export default class User {
 
   _refreshSavedSession() {
     // only update saved session if we previously saved something
-    if (localStorage.getItem(storageKey)) {
+    if (storage.getItem(storageKey)) {
       this._saveSession();
     }
     return this;
@@ -175,7 +177,7 @@ export default class User {
   }
 
   _saveSession() {
-    localStorage.setItem(storageKey, JSON.stringify(this._details));
+    storage.setItem(storageKey, JSON.stringify(this._details));
     return this;
   }
 
@@ -204,7 +206,7 @@ function urlBase64Decode(str) { // From https://jwt.io/js/jwt.js
     default:
       throw 'Illegal base64url string!';
   }
-  var result = window.atob(output); //polifyll https://github.com/davidchambers/Base64.js
+  var result = atob(output); //polifyll https://github.com/davidchambers/Base64.js
   try{
     return decodeURIComponent(escape(result));
   } catch (err) {

--- a/src/utils/atob.js
+++ b/src/utils/atob.js
@@ -1,0 +1,11 @@
+const isomorphicBase64 = require('isomorphic-base64');
+
+let atob;
+if (typeof window !== "undefined" && typeof window.atob === "function") {
+  atob = window.atob;
+}
+else {
+  atob = isomorphicBase64.atob;
+}
+
+export default atob;

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,16 @@
+let storage;
+
+if (typeof localStorage === "undefined") {
+  storage = {
+    _data       : {},
+    setItem     : function(id, val) { return this._data[id] = String(val); },
+    getItem     : function(id) { return this._data.hasOwnProperty(id) ? this._data[id] : undefined; },
+    removeItem  : function(id) { return delete this._data[id]; },
+    clear       : function() { return this._data = {}; }
+  };
+}
+else {
+  storage = localStorage;
+}
+
+export default storage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,11 +1497,21 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+es6-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2003,7 +2013,7 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-iconv-lite@^0.4.17:
+iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -2197,6 +2207,10 @@ is-resolvable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.1.tgz#acca1cd36dbe44b974b924321555a70ba03b1cf4"
 
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -2218,6 +2232,17 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isomorphic-base64@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz#f426aae82569ba8a4ec5ca73ad21a44ab1ee7803"
+
+isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2509,6 +2534,13 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-pre-gyp@^0.6.29:
   version "0.6.32"
@@ -3459,6 +3491,10 @@ vm-browserify@~0.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
Adds `es6-promise`, `isomorphic-base64` & `isomorphic-fetch` as deps.

Note : Browser version grow from `19ko` to `45ko` or (`30ko` w/o es6-promise polyfill).