### PR TITLE
Strip babel helpers from output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["env"],
   "plugins": [
     "syntax-object-rest-spread",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Mathias Biilmann Christensen",
   "bugs": "https://github.com/netlify/micro-api-client-lib/issues",
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "micro-api-client": "^3.2.1"
   },
   "devDependencies": {
@@ -12,6 +13,7 @@
     "babel-eslint": "^8.2.1",
     "babel-plugin-syntax-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babelify": "^7.3.0",
     "browserify": "^14.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,6 +710,12 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "0.9.8"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz#e008df01340fdc87e959da65991b7e05970c8c7c"


### PR DESCRIPTION
Continuing my quest to make this library smaller, I introduced `babel-plugin-transform-runtime` that will strip the babel helpers (like `_createClass` and such) from the compiled code and require them from `babel-runtime` instead. I'm sure you're familiar with the process. :)