### PR TITLE
Added confirm parameter to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Example response:
 
 ### Create a new user
 
-This function creates a new user object with the specified new email and password and other optional attributes.
+This function creates a new user object with the specified new email and password and other optional attributes. User will not be confirmed unless `confirm` parameter is set to true.
 
 ```js
 createUser(email, password, attributes = {}) {
@@ -688,7 +688,7 @@ exports.handler = async (event, context) => {
     return fetch(usersUrl, {
       method: "POST",
       headers: { Authorization: adminAuthHeader },
-      body: JSON.stringify({ email: "new-email@netlify.com", password: "newpw" })
+      body: JSON.stringify({ email: "new-email@netlify.com", password: "newpw", confirm: true })
     })
       .then(response => {
         return response.json();


### PR DESCRIPTION
As it stands, the "Create a new user" documentation does not explicitly say that if you do not send the "confirm" parameter along with the request the new user will not be confirmed. This happens regardless of whether the account has the "Autoconfirm" setting enabled (and rightly so as there might be cases where you want to trigger your own confirmation). However, it might be a good idea to send off a confirmation email if the confirm parameter is set to false (this doesn't happen now).