### PR TITLE
fix: return a rejected promise when inner token is null or undefined

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -61,7 +61,13 @@ export default class User {
   }
 
   jwt(forceRefresh) {
-    const { expires_at, refresh_token, access_token } = this.tokenDetails();
+    const token = this.tokenDetails();
+    if (token === null || token === undefined) {
+      return Promise.reject(
+        new Error(`Gotrue-js: failed getting jwt access token`)
+      );
+    }
+    const { expires_at, refresh_token, access_token } = token;
     if (forceRefresh || expires_at - ExpiryMargin < Date.now()) {
       return this._refreshToken(refresh_token);
     }


### PR DESCRIPTION
Related to https://github.com/netlify/netlify-cms/issues/941, specifically https://github.com/netlify/netlify-cms/issues/941#issuecomment-635265078

When a call to `_refreshToken ` inside the `jwt` methods fails, the inner token property is set to null here:
https://github.com/netlify/gotrue-js/blob/7f85187e22247d8b615aea3a8543711961c4dac7/src/user.js#L95

That can happen when the refresh token is no longer valid as specified here https://github.com/netlify/netlify-identity-widget/issues/142#issuecomment-395894548

Subsequence calls to `jwt` will fail when trying to access a null token, but won't return a rejected promise thus breaking `catch` clauses like these ones:
https://github.com/netlify/gotrue-js/blob/7f85187e22247d8b615aea3a8543711961c4dac7/src/user.js#L72
https://github.com/netlify/netlify-identity-widget/blob/c104dd18bb3b87d2a66936e15f064d5659259686/src/state/store.js#L146

since `jwt` is called on each `_request` that makes error handling very problematic once a refresh operation fails.

The fix is to return a rejected promise if the token is `null` or `undefined`