### PR TITLE
fix(security) no token logging on claims parsing errors

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -156,11 +156,7 @@ export default class User {
       claims = JSON.parse(urlBase64Decode(tokenResponse.access_token.split('.')[1]));
       this.token.expires_at = claims.exp * 1000;
     } catch (e) {
-      console.error(
-        new Error(
-          `Gotrue-js: Failed to parse tokenResponse claims: ${JSON.stringify(tokenResponse)}`,
-        ),
-      );
+      console.error(new Error(`Gotrue-js: Failed to parse tokenResponse claims: ${e}`));
     }
   }
 


### PR DESCRIPTION
This relates to https://github.com/netlify/gotrue-js/issues/259

I've made the following changes: 
1. No more token logging when the error is thrown
2. The original error message is included in the log instead (copied this pattern from elsewhere in the repo)

Cheers!