### PR TITLE
fix(security): no token logging on claims parsing errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2155,6 +2155,41 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -4727,6 +4762,12 @@
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
       }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -7674,6 +7715,12 @@
         "object.assign": "^4.1.2"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "kebab-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
@@ -8393,6 +8440,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -12717,6 +12777,23 @@
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -13846,6 +13923,20 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
     },
+    "sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      }
+    },
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -14716,6 +14807,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "esm": "^3.2.25",
     "nyc": "^15.1.0",
     "semantic-release": "^17.1.1",
+    "sinon": "^9.2.4",
     "typescript": "^4.0.0",
     "uglify-js": "^3.0.0"
   },

--- a/src/user.js
+++ b/src/user.js
@@ -154,11 +154,7 @@ export default class User {
       const claims = JSON.parse(urlBase64Decode(tokenResponse.access_token.split('.')[1]));
       this.token.expires_at = claims.exp * 1000;
     } catch (error) {
-      console.error(
-        new Error(
-          `Gotrue-js: Failed to parse tokenResponse claims: ${JSON.stringify(tokenResponse)}`,
-        ),
-      );
+      console.error(new Error(`Gotrue-js: Failed to parse tokenResponse claims: ${error}`));
     }
   }
 

--- a/tests/user.js
+++ b/tests/user.js
@@ -26,7 +26,7 @@ test('should parse token in ctor', (t) => {
   t.is(user.token.expires_at, 1000000);
 });
 
-test('should not log token on error', (t) => {
+test.serial('should not log token on error', (t) => {
   const spy = sinon.spy(console, 'error');
   const tokenResponse = {
     access_token: 'header.invalid.secret',

--- a/tests/user.js
+++ b/tests/user.js
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 
 import test from 'ava';
+import sinon from 'sinon';
 
 import User from '../src/user.js';
 
@@ -23,4 +24,19 @@ test('should parse token in ctor', (t) => {
   const user = new User({}, tokenResponse, '');
 
   t.is(user.token.expires_at, 1000000);
+});
+
+test('should not log token on error', (t) => {
+  const spy = sinon.spy(console, 'error');
+  const tokenResponse = {
+    access_token: 'header.invalid.secret',
+  };
+
+  // eslint-disable-next-line no-new
+  new User({}, tokenResponse, '');
+
+  t.assert(spy.calledOnce);
+  const [error] = spy.getCall(0).args;
+  t.true(error instanceof Error);
+  t.false(error.message.includes(tokenResponse.access_token));
 });


### PR DESCRIPTION
Replaces https://github.com/netlify/gotrue-js/pull/265.

I `git cherry pick` the commit instead of pushing to that PR since it as opened from `master`.

Added a test case for the reported issue.