### PR TITLE
chore: run CI on latest Node.js

### DIFF
--- a/.github/workflows/babelify.yml
+++ b/.github/workflows/babelify.yml
@@ -13,7 +13,8 @@ jobs:
           token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
       - uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: '*'
+          check-latest: true
       - name: Install dependencies
         run: npm ci
       - run: npm run babelify

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: [15.x]
+        node-version: ['*']
 
     steps:
       - uses: actions/checkout@v2
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       - name: log versions
         run: node --version && npm --version
       - name: Install dependencies
@@ -39,7 +40,7 @@ jobs:
           os=${{ matrix.os }}
           node=${{ matrix.node-version }}
           echo "::set-output name=os::${os/-latest/}"
-          echo "::set-output name=node::node_${node//./}"
+          echo "::set-output name=node::node_${node//[.*]/}"
         shell: bash
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '*'
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - name: Install dependencies


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/19

This runs the CI on the `latest` Node.js version.