### PR TITLE
fix: cutom headers overwrite the auth header

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -113,10 +113,10 @@ export default class User {
     try {
       const token = await this.jwt();
       return await this.api.request(path, {
+        ...options,
         headers: Object.assign(options.headers, {
           Authorization: `Bearer ${token}`,
         }),
-        ...options,
       });
     } catch (error) {
       if (error instanceof JSONHTTPError && error.json) {


### PR DESCRIPTION
Hey :wave:
If user set an audience `aud` property or provide a customs `headers`, those headers are overwriting the `Authorization`.

```javascript
auth = new GoTrue({
  APIUrl: 'https://<your domain name>/.netlify/identity',
  audience: 'SOME-CONTEXT',
  setCookie: false,
});
```

Have a great day 😄 