### PR TITLE
chore: fix labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,11 @@ jobs:
   label-pr:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     strategy:
+      fail-fast: false
       matrix:
         pr:
           [


### PR DESCRIPTION
Right now it's not possible for the PR labeler to label PR's, which means it fails constantly. This should fix that: